### PR TITLE
Fixing babel transpiler errors. windows environments need to normaliz…

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -1,5 +1,5 @@
 // Node modules
-var fs = require('fs'), vm = require('vm'), merge = require('deeply'), chalk = require('chalk'), es = require('event-stream'), path = require('path'), url = require('url');
+var fs = require('fs'), vm = require('vm'), merge = require('deeply'), chalk = require('chalk'), es = require('event-stream'), path = require('path'), url = require('url'), slash = require('slash');
 
 // Gulp and plugins
 var gulp = require('gulp'), rjs = require('gulp-requirejs-bundler'), concat = require('gulp-concat'), clean = require('gulp-clean'), filter = require('gulp-filter'),
@@ -130,6 +130,7 @@ gulp.task('serve:dist', ['default'], function() {
 });
 
 function babelTranspile(pathname, callback) {
+    pathname = slash(pathname);
     if (babelIgnoreRegexes.some(function (re) { return re.test(pathname); })) return callback();
     if (!babelCore.canCompile(pathname)) return callback();
     var src  = path.join(transpilationConfig.root, pathname);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,6 +2,7 @@
   "name": "<%= slugName %>",
   "version": "0.0.0",
   "devDependencies": {
+    "babel-core": "^5.8.25",
     "gulp": "^3.6.2",
     "gulp-requirejs-bundler": "^0.1.1",
     "gulp-concat": "~2.2.0",
@@ -26,6 +27,7 @@
     "requirejs": "^2.1.11",
 <% } %>
     "deeply": "~0.1.0",
-    "chalk": "~0.4.0"
+    "chalk": "~0.4.0",
+    "slash": "^1.0.0"
   }
 }


### PR DESCRIPTION
Tried running the generator in windows and got two different errors:
1. babel-core was not added as a dev-dependency
2. skipped files/folders in transpilationConfig (gulpfile.js) were not matching any files under windows due to the path separator differences between the Regex strings and the pathnames, this gives many babel transpilation errors for files in node_modules (jquery being one of the first)

I added both the babel-core npm depepdency and the normalization/conversion of backslashes to posix dir separators (by using github.com/sindresorhus/slash) before transpilation occurs.
